### PR TITLE
Remove step to commit and push SHA256 hashes CSV

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -86,14 +86,6 @@ jobs:
                         echo "$file,$hash" >> sha256_hashes.csv
                     done
 
-            - name: 'Commit and push hash file'
-              run: |
-                    git config --global user.name "github-actions[bot]"
-                    git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                    git add sha256_hashes.csv
-                    git commit -m "Update SHA256 hashes CSV [skip ci]" || echo "No changes to commit"
-                    git push
-
     release:
         runs-on: ubuntu-latest
         name: 'Create release'


### PR DESCRIPTION
Eliminated the workflow step that committed and pushed the sha256_hashes.csv file. This change prevents automated commits to the repository