### PR TITLE
Add custom PSScriptAnalyzer rule for lowercase keywords

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -36,6 +36,7 @@ jobs:
           with:
             path: "./Apps"
             recurse: true
+            settings: ".rules/PSScriptAnalyzerSettings.psd1"
             output: results.sarif
 
         # Upload the SARIF file generated in the previous step

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
           with:
             path: "./Apps"
             recurse: true
-            includeDefaultRules: true 
+            includeDefaultRules: true
             settings: "./.rules/PSScriptAnalyzerSettings.psd1"
             customRulePath: "./.rules/LowercaseKeywords.psm1"
             output: results.sarif

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,9 @@ jobs:
           with:
             path: "./Apps"
             recurse: true
+            includeDefaultRules: true 
+            settings: "./.rules/PSScriptAnalyzerSettings.psd1"
+            customRulePath: "./.rules/LowercaseKeywords.psm1"
             output: results.sarif
 
         # Upload the SARIF file generated in the previous step

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,9 +30,7 @@ jobs:
           with:
             path: "./Apps"
             recurse: true
-            includeDefaultRules: true
-            settings: "./.rules/PSScriptAnalyzerSettings.psd1"
-            customRulePath: "./.rules/LowercaseKeywords.psm1"
+            settings: ".rules/PSScriptAnalyzerSettings.psd1"
             output: results.sarif
 
         # Upload the SARIF file generated in the previous step

--- a/.rules/LowercaseKeywords.psm1
+++ b/.rules/LowercaseKeywords.psm1
@@ -1,0 +1,44 @@
+# LowercaseKeywords.psm1
+using namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
+
+function Measure-LowercaseKeywords {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $ScriptAst,
+
+        [Parameter(Mandatory)]
+        [string] $ScriptPath
+    )
+
+    process {
+        # Tokenize the script
+        $parseErrors = @()
+        $tokens = [System.Management.Automation.PSParser]::Tokenize($ScriptAst, [ref]$parseErrors)
+
+        if ($parseErrors) {
+            return
+        }
+
+        # Define what we care about
+        $keywords = @('function', 'foreach', 'if')
+        $constants = @('`$true', '`$false', '`$null')
+        $targets = $keywords + $constants
+
+        foreach ($t in $tokens) {
+            $actual = $t.Content
+            $lower = $actual.ToLower()
+
+            if ($targets -contains $lower) {
+                if ($actual -cne $lower) {
+                    [DiagnosticRecord]@{
+                        Message  = "Keyword/constant '$actual' should be lowercase ('$lower')."
+                        Extent   = $t.Extent
+                        RuleName = 'LowercaseKeywords'
+                        Severity = 'Warning'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.rules/LowercaseKeywords.psm1
+++ b/.rules/LowercaseKeywords.psm1
@@ -20,13 +20,19 @@ function Measure-LowercaseKeywords {
         # Find all CommandElements and VariableExpressions in the AST
         $nodes = $ScriptAst.FindAll({
             param($node)
-            # Check for command keywords
+            # Only return true for relevant command keywords or variable constants
             if ($node -is [System.Management.Automation.Language.CommandElementAst]) {
-                return $true
-            }
-            # Check for variable constants
-            if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
-                return $true
+                $actual = $node.Extent.Text
+                $lower = $actual.ToLower()
+                if ($keywords -contains $lower) {
+                    return $true
+                }
+            } elseif ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                $actual = $node.Extent.Text
+                $lower = $actual.ToLower()
+                if ($constants -contains $lower) {
+                    return $true
+                }
             }
             return $false
         }, $true)

--- a/.rules/LowercaseKeywords.psm1
+++ b/.rules/LowercaseKeywords.psm1
@@ -22,7 +22,7 @@ function Measure-LowercaseKeywords {
 
         # Define what we care about
         $keywords = @('function', 'foreach', 'if')
-        $constants = @('`$true', '`$false', '`$null')
+        $constants = @('$true', '$false', '$null')
         $targets = $keywords + $constants
 
         foreach ($t in $tokens) {

--- a/.rules/PSScriptAnalyzerSettings.psd1
+++ b/.rules/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,8 @@
+@{
+    CustomRulePath = @(
+        "$PSScriptRoot\LowercaseKeywords.psm1"
+    )
+    IncludeRules   = @(
+        'LowercaseKeywords'
+    )
+}

--- a/.rules/PSScriptAnalyzerSettings.psd1
+++ b/.rules/PSScriptAnalyzerSettings.psd1
@@ -1,8 +1,8 @@
 @{
-    CustomRulePath = @(
-        "$PSScriptRoot\LowercaseKeywords.psm1"
-    )
-    IncludeRules   = @(
-        'LowercaseKeywords'
+    CustomRulePath      = @(".rules/LowercaseKeywords.psm1")
+    IncludeDefaultRules = $true
+    Severity            = @("Error", "Warning")
+    IncludeRules        = @(
+        "Measure*"
     )
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "files.eol": "\n"
+    "files.eol": "\n",
+    "powershell.scriptAnalysis.settingsPath": ".rules/PSScriptAnalyzerSettings.psd1",
+    "powershell.scriptAnalysis.enable": true
 }


### PR DESCRIPTION
Introduces a custom PowerShell Script Analyzer rule to enforce lowercase usage for specific keywords and constants. Updates the GitHub Actions workflow to use this rule and a new analyzer settings file for validation.