### PR TITLE
Add FilePath parameter to Measure-LowercaseKeywords

### DIFF
--- a/.rules/LowercaseKeywords.psm1
+++ b/.rules/LowercaseKeywords.psm1
@@ -7,7 +7,11 @@ function Measure-LowercaseKeywords {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.Language.ScriptBlockAst]$ScriptAst
+        [System.Management.Automation.Language.ScriptBlockAst]$ScriptAst,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]$FilePath
     )
 
     process {
@@ -30,10 +34,9 @@ function Measure-LowercaseKeywords {
             if ($targets -contains $lower) {
                 if ($actual -cne $lower) {
                     [System.String]$correction = 'Update keyword/constant to lowercase.'
-                    [System.String]$file = $MyInvocation.MyCommand.Definition
                     $params = @{
                         TypeName     = 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent'
-                        ArgumentList = $t.StartLine, $t.EndLine, $t.StartColumn, $t.EndColumn, $correction, $file
+                        ArgumentList = $t.StartLine, $t.EndLine, $t.StartColumn, $t.EndColumn, $correction, $FilePath
                     }
                     $correctionExtent = New-Object @params
                     $suggestedCorrections = New-Object -TypeName System.Collections.ObjectModel.Collection[$($params.TypeName)]

--- a/.rules/LowercaseKeywords.psm1
+++ b/.rules/LowercaseKeywords.psm1
@@ -10,7 +10,6 @@ function Measure-LowercaseKeywords {
         [System.Management.Automation.Language.ScriptBlockAst]$ScriptAst,
 
         [Parameter(Mandatory = $false)]
-        [ValidateNotNullOrEmpty()]
         [System.String]$FilePath
     )
 


### PR DESCRIPTION
Introduces an optional FilePath parameter to the Measure-LowercaseKeywords function and uses it for correction extent reporting instead of relying on $MyInvocation. This improves accuracy when reporting file locations for keyword corrections.