### PR TITLE
Add RustDesk Client manifest and retrieval script

### DIFF
--- a/Apps/Get-RustDeskClient.ps1
+++ b/Apps/Get-RustDeskClient.ps1
@@ -1,0 +1,26 @@
+function Get-RustDeskClient {
+    <#
+        .SYNOPSIS
+            Returns the latest RustDesk Client version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Manifests/RustDeskClient.json
+++ b/Manifests/RustDeskClient.json
@@ -1,0 +1,9 @@
+{
+	"Name": "RustDesk Client",
+	"Source": "https://rustdesk.com/docs/en/self-host/client-deployment/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/rustdesk/rustdesk/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$"
+	}
+}


### PR DESCRIPTION
Introduces Get-RustDeskClient.ps1 to fetch the latest RustDesk Client release information from GitHub, and adds a corresponding manifest file with metadata and API details for version and file matching.