### PR TITLE
Add Trimble SketchUp #56

### DIFF
--- a/Apps/Get-TrimbleSketchUp.ps1
+++ b/Apps/Get-TrimbleSketchUp.ps1
@@ -1,0 +1,43 @@
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2510.2817.0" }
+function Get-TrimbleSketchUp {
+    <#
+        .SYNOPSIS
+            Returns the latest Trimble SketchUp version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Get the update details from the API
+    $params = @{
+        Uri       = $res.Get.Update.Uri
+        UserAgent = $res.Get.Update.UserAgent
+    }
+    $Payload = Invoke-EvergreenRestMethod @params
+    
+    # Convert the JWT token payload
+    $ConvertedPayload = ConvertFrom-Jwt -Token $Payload.token
+    Write-Verbose -Message "$($MyInvocation.MyCommand): Found version: $($ConvertedPayload.Payload.versions.versionNumber)"
+    Write-Verbose -Message "$($MyInvocation.MyCommand):     Found URL: $($ConvertedPayload.Payload.versions.installerUrl)"
+
+    # Modify the URL to get the full installer
+    $Url = $ConvertedPayload.Payload.versions.installerUrl -replace $res.Get.Download.ConvertUrl, '$1Full$2'
+    Write-Verbose -Message "$($MyInvocation.MyCommand):  Converted to: $Url"
+
+    # Build object and output to the pipeline
+    $PSObject = [PSCustomObject] @{
+        Version = $ConvertedPayload.Payload.versions.versionNumber
+        Date    = ConvertTo-DateTime -DateTime $ConvertedPayload.Payload.versions.releaseDate -Pattern $res.Get.Update.DateTimePattern
+        Type    = Get-FileType -File $Url
+        URI     = $Url
+    }
+    Write-Output -InputObject $PSObject
+}

--- a/Manifests/TrimbleSketchUp.json
+++ b/Manifests/TrimbleSketchUp.json
@@ -1,0 +1,16 @@
+{
+    "Name": "Trimble SketchUp",
+    "Source": "https://help.sketchup.com/en/sketchup/performing-silent-install-sketchup",
+    "Get": {
+        "Update": {
+            "Uri": "https://api.sketchup.com/updater/v1/windows/en/25.0.429",
+            "UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.7151.121 SketchUp Pro/26.0 (PC) Safari/537.36",
+            "DateTimePattern": "yyyy-MM-dd"
+        },
+        "Download": {
+            "Uri": "",
+            "ConvertUrl": "(https://download\\.sketchup\\.com/SketchUp)(-\\d)",
+            "ReplaceText": "Full"
+        }
+    }
+}


### PR DESCRIPTION
Introduced `Get-TrimbleSketchUp.ps1` to fetch the latest Trimble SketchUp version and download URL using the Evergreen module. Added TrimbleSketchUp.json manifest with update and download configuration details.