### PR TITLE
Address #59

### DIFF
--- a/Manifests/Microsoft.NET.json
+++ b/Manifests/Microsoft.NET.json
@@ -8,7 +8,8 @@
             "Channels": [
                 "STS",
                 "LTS",
-                "6.0"
+                "9.0",
+                "8.0"
             ]
         },
         "Download": {


### PR DESCRIPTION
Updated the `Microsoft.NET.json` manifest to include the new `9.0` and `8.0` channels in the Channels list, ensuring support for the latest .NET versions. Removes `6.0` because that version is out of support