### PR TITLE
Update download URI category for Horizon Client #67

### DIFF
--- a/Manifests/OmnissaHorizonClient.json
+++ b/Manifests/OmnissaHorizonClient.json
@@ -6,7 +6,7 @@
             "Uri": ""
         },
         "Download": {
-            "Uri": "https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=omnissa_horizon_clients&version=8&dlgType=PRODUCT_BINARY",
+            "Uri": "https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=virtual_desktop_and_apps&product=omnissa_horizon_clients&version=8&dlgType=PRODUCT_BINARY",
             "ProductName": "Omnissa Horizon Client for Windows",
             "QueryUri": "https://customerconnect.omnissa.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=#ProductCode&productId=#ProductId&rPId=#PackageId",
             "MatchVersion": "(\\d+(\\.\\d+){1,3})",


### PR DESCRIPTION
* Changed the 'category' parameter in the Download URI from 'desktop_end_user_computing' to 'virtual_desktop_and_apps' to reflect updated product categorization. Fixes #67