### PR TITLE
Update Chrome extended download URL

### DIFF
--- a/Manifests/GoogleChrome.json
+++ b/Manifests/GoogleChrome.json
@@ -17,7 +17,7 @@
         },
         "Download": {
             "Uri": {
-                "Extended": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
+                "Extended": "https://dl.google.com/dl/chrome/install/extended/googlechromestandaloneenterprise64.msi",
                 "Stable": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
                 "Beta": "https://dl.google.com/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi",
                 "Dev": "https://dl.google.com/dl/chrome/install/dev/googlechromedevstandaloneenterprise64.msi",


### PR DESCRIPTION
Changed the 'Extended' download URI for Google Chrome to include the '/extended/' path, ensuring the correct installer is referenced.