### PR TITLE
Update Fusion 360 #89

### DIFF
--- a/Manifests/AutodeskFusion360.json
+++ b/Manifests/AutodeskFusion360.json
@@ -7,7 +7,7 @@
         },
         "Download": {
             "Uri": {
-                "exe": "https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe"
+                "exe": "https://dl.appstreaming.autodesk.com/production/installers/Fusion%20Admin%20Install.exe"
             }
         }
     },


### PR DESCRIPTION
Changed the download URI for the Fusion 360 installer to the new 'Fusion Admin Install.exe' endpoint. Closes #89