### PR TITLE
Align variable names. Fix #95

### DIFF
--- a/Apps/Get-MicrosoftSsms.ps1
+++ b/Apps/Get-MicrosoftSsms.ps1
@@ -18,7 +18,7 @@ function Get-MicrosoftSsms {
     )
 
     $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri
-    if ($ResolvedUrl) {
+    if ($ResolvedUrl.ResponseUri -is [System.Uri]) {
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
             Version = $res.Get.Download.Version

--- a/Apps/Get-MicrosoftSsms20.ps1
+++ b/Apps/Get-MicrosoftSsms20.ps1
@@ -22,17 +22,16 @@ function Get-MicrosoftSsms20 {
         $Query = "&clcid="
         $Uri = "$($res.Get.Download.Uri)$($Query)$($res.Get.Download.Language[$language.key])"
         Write-Verbose -Message "$($MyInvocation.MyCommand): Resolving: $Uri"
-        $ResponseUri = Resolve-SystemNetWebRequest -Uri $Uri
+        $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $Uri
 
-        if ($ResponseUri.ResponseUri -is [System.Uri]) {
-
+        if ($ResolvedUrl.ResponseUri -is [System.Uri]) {
             # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
                 Version  = $res.Get.Download.Version
-                Date     = $ResponseUri.LastModified.ToShortDateString()
+                Date     = $ResolvedUrl.LastModified.ToShortDateString()
                 Language = $language.key
                 Type     = Get-FileType -File $ResolvedUrl.ResponseUri.AbsoluteUri
-                URI      = $ResponseUri.ResponseUri.AbsoluteUri
+                URI      = $ResolvedUrl.ResponseUri.AbsoluteUri
             }
             Write-Output -InputObject $PSObject
         }

--- a/Apps/Get-MicrosoftSsms21.ps1
+++ b/Apps/Get-MicrosoftSsms21.ps1
@@ -18,7 +18,7 @@ function Get-MicrosoftSsms21 {
     )
 
     $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri
-    if ($ResolvedUrl) {
+    if ($ResolvedUrl.ResponseUri -is [System.Uri]) {
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
             Version = $res.Get.Download.Version


### PR DESCRIPTION
Updated Get-MicrosoftSsms, Get-MicrosoftSsms20, and Get-MicrosoftSsms21 scripts to standardise on $ResolvedUrl variable and explicitly check if ResolvedUrl.ResponseUri is a System.Uri before proceeding.