### PR TITLE
Add version to ODBC/OLEDB driver manifests and scripts

### DIFF
--- a/Apps/Get-MicrosoftODBCDriverForSQLServer.ps1
+++ b/Apps/Get-MicrosoftODBCDriverForSQLServer.ps1
@@ -22,7 +22,7 @@ function Get-MicrosoftODBCDriverForSQLServer {
                 Uri                = $Uri
                 MaximumRedirection = $res.Get.Download.MaximumRedirection
             }
-            Resolve-MicrosoftFwLink @params | ForEach-Object { $_.Language = $language.key; $_ } | Write-Output
+            Resolve-MicrosoftFwLink @params | ForEach-Object { $_.Version = $res.Get.Download.Version; $_.Language = $language.key; $_ } | Write-Output
         }
     }
 }

--- a/Apps/Get-MicrosoftOLEDBDriverForSQLServer.ps1
+++ b/Apps/Get-MicrosoftOLEDBDriverForSQLServer.ps1
@@ -22,7 +22,7 @@ function Get-MicrosoftOLEDBDriverForSQLServer {
                 Uri                = $Uri
                 MaximumRedirection = $res.Get.Download.MaximumRedirection
             }
-            Resolve-MicrosoftFwLink @params | ForEach-Object { $_.Language = $language.key; $_ } | Write-Output
+            Resolve-MicrosoftFwLink @params | ForEach-Object { $_.Version = $res.Get.Download.Version; $_.Language = $language.key; $_ } | Write-Output
         }
     }
 }

--- a/Manifests/MicrosoftODBCDriverForSQLServer.json
+++ b/Manifests/MicrosoftODBCDriverForSQLServer.json
@@ -6,6 +6,7 @@
             "Uri": ""
         },
         "Download": {
+            "Version": "18.6.1.1",
             "Uri": [
                 "https://go.microsoft.com/fwlink/?linkid=2345415",
                 "https://go.microsoft.com/fwlink/?linkid=2346006",

--- a/Manifests/MicrosoftOLEDBDriverForSQLServer.json
+++ b/Manifests/MicrosoftOLEDBDriverForSQLServer.json
@@ -6,6 +6,7 @@
             "Uri": ""
         },
         "Download": {
+            "Version": "19.4.1",
             "Uri": [
                 "https://go.microsoft.com/fwlink/?linkid=2318101",
                 "https://go.microsoft.com/fwlink/?linkid=2318001"


### PR DESCRIPTION
Updated MicrosoftODBCDriverForSQLServer.json and MicrosoftOLEDBDriverForSQLServer.json to include a Download.Version field. Modified corresponding PowerShell scripts to set the Version property on resolved download links. Address #94