### PR TITLE
Fix GitHub release URI validation #102

### DIFF
--- a/Apps/Get-GitHubRelease.ps1
+++ b/Apps/Get-GitHubRelease.ps1
@@ -27,11 +27,11 @@ function Get-GitHubRelease {
 
         [Parameter(Mandatory = $false, Position = 1)]
         [ValidateScript( {
-                if ($_ -match "^(https://api\.github\.com/repos/)([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)(/releases)$") {
+                if ($_ -match "^(https://api\.github\.com/repos/)([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/releases(?:/latest|/[a-zA-Z0-9._-]+)?$") {
                     $true
                 }
                 else {
-                    throw "'$_' must be in the format 'https://api.github.com/repos/user/repository/releases/latest'. Replace 'user' with the user or organisation and 'repository' with the target repository name."
+                    throw "'$_' must be in the format 'https://api.github.com/repos/user/repository/releases', 'https://api.github.com/repos/user/repository/releases/latest', or 'https://api.github.com/repos/user/repository/releases/RELEASE_ID'. Replace 'user' with the user or organisation, 'repository' with the target repository name, and 'RELEASE_ID' with a valid release identifier."
                 }
             })]
         [System.String] $Uri = "https://api.github.com/repos/atom/atom/releases/latest"


### PR DESCRIPTION
Updated the URI validation regex and error message to accept 'releases', 'releases/latest', and 'releases/RELEASE_ID' formats. This allows the function to support more GitHub release API endpoints. Addresses #102 