### PR TITLE
Update AzulZulu for FX releases #87

### DIFF
--- a/Apps/Get-AzulZulu11.ps1
+++ b/Apps/Get-AzulZulu11.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2511.2823.0" }
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2603.2832.0" }
 function Get-AzulZulu11 {
     <#
         .NOTES

--- a/Apps/Get-AzulZulu17.ps1
+++ b/Apps/Get-AzulZulu17.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2511.2823.0" }
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2603.2832.0" }
 function Get-AzulZulu17 {
     <#
         .NOTES

--- a/Apps/Get-AzulZulu21.ps1
+++ b/Apps/Get-AzulZulu21.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2511.2823.0" }
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2603.2832.0" }
 function Get-AzulZulu21 {
     <#
         .NOTES

--- a/Apps/Get-AzulZulu25.ps1
+++ b/Apps/Get-AzulZulu25.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2511.2823.0" }
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2603.2832.0" }
 function Get-AzulZulu25 {
     <#
         .NOTES

--- a/Apps/Get-AzulZulu8.ps1
+++ b/Apps/Get-AzulZulu8.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2511.2823.0" }
+#Requires -Module @{ ModuleName="Evergreen"; ModuleVersion="2603.2832.0" }
 function Get-AzulZulu8 {
     <#
         .NOTES

--- a/Manifests/AzulZulu11.json
+++ b/Manifests/AzulZulu11.json
@@ -3,7 +3,7 @@
     "Source": "https://www.azul.com/downloads/#zulu",
     "Get": {
         "Update": {
-            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=11&os=windows&archive_type=msi&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
+            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=11&os=windows&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
             "ContentType": "application/json"
         }
     },

--- a/Manifests/AzulZulu17.json
+++ b/Manifests/AzulZulu17.json
@@ -3,7 +3,7 @@
     "Source": "https://www.azul.com/downloads/#zulu",
     "Get": {
         "Update": {
-            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=17&os=windows&archive_type=msi&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
+            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=17&os=windows&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
             "ContentType": "application/json"
         }
     },

--- a/Manifests/AzulZulu21.json
+++ b/Manifests/AzulZulu21.json
@@ -3,7 +3,7 @@
     "Source": "https://www.azul.com/downloads/#zulu",
     "Get": {
         "Update": {
-            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=21&os=windows&archive_type=msi&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
+            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=21&os=windows&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
             "ContentType": "application/json"
         }
     },

--- a/Manifests/AzulZulu25.json
+++ b/Manifests/AzulZulu25.json
@@ -3,7 +3,7 @@
     "Source": "https://www.azul.com/downloads/#zulu",
     "Get": {
         "Update": {
-            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=25&os=windows&archive_type=msi&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
+            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=25&os=windows&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
             "ContentType": "application/json"
         }
     }

--- a/Manifests/AzulZulu8.json
+++ b/Manifests/AzulZulu8.json
@@ -3,7 +3,7 @@
     "Source": "https://www.azul.com/downloads/#zulu",
     "Get": {
         "Update": {
-            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=8&os=windows&archive_type=msi&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
+            "Uri": "https://api.azul.com/metadata/v1/zulu/packages/?java_version=8&os=windows&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck&page=1&page_size=100",
             "ContentType": "application/json"
         }
     },


### PR DESCRIPTION
* Remove the `archive_type=msi` query parameter from AzulZulu manifest Update URIs so the API queries are not restricted to MSI archives.
* Update Evergreen module requirement in Get-AzulZulu PS1 scripts from `2511.2823.0` to `2603.2832.0` - this now supports JRE FX and JDK FX.
* Changes apply to `Apps/Get-AzulZulu{8,11,17,21,25}.ps1` and `Manifests/AzulZulu{8,11,17,21,25}.json`.