### PR TITLE
Update URI in KubernetesKubectl.json 

### DIFF
--- a/Manifests/KubernetesKubectl.json
+++ b/Manifests/KubernetesKubectl.json
@@ -3,7 +3,7 @@
     "Source": "https://kubernetes.io/",
     "Get": {
         "Update": {
-            "Uri": "https://cdn.dl.k8s.io/release/stable.txt"
+            "Uri": "https://dl.k8s.io/release/stable.txt"
         },
         "Download": {
             "Uri": {


### PR DESCRIPTION
Fixes https://github.com/EUCPilots/evergreen-apps/issues/115

Removes cdn from the URI - as it is not valid anymore.

Seems to work after editing:

Get-EvergreenApp -Name KubernetesKubectl -Verbose -Debug
VERBOSE: Function path: C:\Users\escal\AppData\Local\Evergreen\Apps\Get-KubernetesKubectl.ps1
VERBOSE: Function exists: C:\Users\escal\AppData\Local\Evergreen\Apps\Get-KubernetesKubectl.ps1.
VERBOSE: Dot sourcing: C:\Users\escal\AppData\Local\Evergreen\Apps\Get-KubernetesKubectl.ps1.
VERBOSE: Get-FunctionResource: read application resource strings from
[C:\Users\escal\AppData\Local\Evergreen\Manifests\KubernetesKubectl.json]
VERBOSE: Calling: Get-KubernetesKubectl.
VERBOSE: GET with 0-byte payload
VERBOSE: received 7-byte response of content type text/plain

Version Architecture Platform URI
------- ------------ -------- ---
1.35.2  x86          Windows  https://dl.k8s.io/release/v1.35.2/bin/windows/386/kubectl.exe
1.35.2  x64          Windows  https://dl.k8s.io/release/v1.35.2/bin/windows/amd64/kubectl.exe
1.35.2  arm64        Windows  https://dl.k8s.io/release/v1.35.2/bin/windows/arm64/kubectl.exe

