### PR TITLE
Use Get-Architecture/Get-FileType helpers

### DIFF
--- a/Apps/Get-KubernetesKubectl.ps1
+++ b/Apps/Get-KubernetesKubectl.ps1
@@ -23,8 +23,8 @@ function Get-KubernetesKubectl {
     foreach ($DownloadUri in $res.Get.Download.Uri.GetEnumerator()) {
         [PSCustomObject] @{
             Version      = $Version.TrimStart("v")
-            Architecture = $DownloadUri.Name.Split("_")[1]
             Platform     = $DownloadUri.Name.Split("_")[0]
+            Architecture = Get-Architecture -String $DownloadUri.Name.Split("_")[1]
             URI          = $DownloadUri.Value -replace $res.Get.Download.ReplaceVersionText, $Version
         }
     }

--- a/Apps/Get-LehrerOffice.ps1
+++ b/Apps/Get-LehrerOffice.ps1
@@ -25,7 +25,7 @@ function Get-LehrerOffice {
     if ($null -ne $Content) {
         $PSObject = [PSCustomObject] @{
             Version = $newestVersion
-            Type    = 'Exe'
+            Type    = Get-FileType -File $res.Get.Download.Uri
             URI     = $res.Get.Download.Uri
         }
         Write-Output -InputObject $PSObject

--- a/Apps/Get-MicrosoftEdge.ps1
+++ b/Apps/Get-MicrosoftEdge.ps1
@@ -34,7 +34,7 @@ function Get-MicrosoftEdge {
                             Expiry                  = $Release.ExpectedExpiryDate
                             $Artifact.HashAlgorithm = $Artifact.Hash
                             Size                    = $([Math]::Round($Artifact.SizeInBytes / 1MB, 2))
-                            Architecture            = $Release.Architecture
+                            Architecture            = Get-Architecture -String $Release.Architecture
                             Type                    = $Artifact.ArtifactName
                             URI                     = $Artifact.Location
                         }

--- a/Apps/Get-MicrosoftEdgeDriver.ps1
+++ b/Apps/Get-MicrosoftEdgeDriver.ps1
@@ -40,7 +40,7 @@ function Get-MicrosoftEdgeDriver {
                     $PSObject = [PSCustomObject] @{
                         Version      = $Release.ProductVersion
                         Channel      = $Channel
-                        Architecture = $Release.Architecture
+                        Architecture = Get-Architecture -String $Release.Architecture
                         URI          = $res.Get.Download.Uri[$Release.Architecture] -replace "#version", $Release.ProductVersion
                     }
                     Write-Output -InputObject $PSObject

--- a/Apps/Get-MicrosoftEdgeForBusiness.ps1
+++ b/Apps/Get-MicrosoftEdgeForBusiness.ps1
@@ -33,7 +33,7 @@ function Get-MicrosoftEdgeForBusiness {
                             Expiry                  = $Release.ExpectedExpiryDate
                             $Artifact.HashAlgorithm = $Artifact.Hash
                             Size                    = $([Math]::Round($Artifact.SizeInBytes / 1MB, 2))
-                            Architecture            = $Release.Architecture
+                            Architecture            = Get-Architecture -String $Release.Architecture
                             Type                    = $Artifact.ArtifactName
                             URI                     = $Artifact.Location
                         }

--- a/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
+++ b/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
@@ -41,7 +41,7 @@ function Get-MicrosoftEdgeWebView2Runtime {
                     $PSObject = [PSCustomObject] @{
                         Version      = $Release.ProductVersion
                         Channel      = $Channel
-                        Architecture = $Release.Architecture
+                        Architecture = Get-Architecture -String $Release.Architecture
                         URI          = $Url
                     }
                     Write-Output -InputObject $PSObject

--- a/Apps/Get-MicrosoftTeams.ps1
+++ b/Apps/Get-MicrosoftTeams.ps1
@@ -29,7 +29,7 @@ function Get-MicrosoftTeams {
                 $PSObject = [PSCustomObject] @{
                     Version      = $Feed.BuildSettings.$($Release.Value).$Item.latestVersion
                     Release      = $Release.Name
-                    Architecture = $Item
+                    Architecture = Get-Architecture -String $Item
                     Type         = Get-FileType -File $Feed.BuildSettings.$($Release.Value).$Item.buildLink
                     URI          = $Feed.BuildSettings.$($Release.Value).$Item.buildLink
                 }


### PR DESCRIPTION
Replace ad-hoc architecture and file type extraction with helper functions for consistency. Columns that previously used raw architecture strings now call Get-Architecture -String, and LehrerOffice Type now uses Get-FileType -File. Updated files: Apps/Get-KubernetesKubectl.ps1, Apps/Get-LehrerOffice.ps1, Apps/Get-MicrosoftEdge.ps1, Apps/Get-MicrosoftEdgeDriver.ps1, Apps/Get-MicrosoftEdgeForBusiness.ps1, Apps/Get-MicrosoftEdgeWebView2Runtime.ps1, Apps/Get-MicrosoftTeams.ps1. This centralizes parsing and ensures consistent architecture and file type values across scripts.