### PR TITLE
Update GoTo app scripts and manifests

### DIFF
--- a/Apps/Get-GoToConnect.ps1
+++ b/Apps/Get-GoToConnect.ps1
@@ -2,7 +2,6 @@
     <#
         .NOTES
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]

--- a/Apps/Get-GoToMeeting.ps1
+++ b/Apps/Get-GoToMeeting.ps1
@@ -2,7 +2,6 @@
     <#
         .NOTES
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]
@@ -13,26 +12,27 @@
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Step through each installer type
-    foreach ($item in $res.Get.Download.Uri.GetEnumerator()) {
+    # Resolve the URL to the target location
+    $Update = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
 
-        # Resolve the URL to the target location
-        $URI = Resolve-InvokeWebRequest -Uri $res.Get.Download.Uri[$item.Key]
+    if ($null -ne $Update) {
+        $Version = [RegEx]::Match($Update, $res.Get.Update.MatchVersion).Captures.Groups[1].Value
 
-        # Match version number
-        try {
-            $Version = [RegEx]::Match($URI, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
-        }
-        catch {
-            $Version = "Unknown"
-        }
+        if ($null -ne $Version) {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Found version: $Version."
 
-        # Build the output object; Output object to the pipeline
-        $PSObject = [PSCustomObject] @{
-            Version = $Version
-            Type    = $item.Name
-            URI     = $(($URI -split $res.Get.Download.Split)[0])
+            foreach ($Architecture in $res.Get.Download.Uri.GetEnumerator()) {
+
+                # Build the output object; Output object to the pipeline
+                $Url = $res.Get.Download.Uri[$Architecture.Key] -replace "#version", $Version
+                $PSObject = [PSCustomObject] @{
+                    Version      = $Version
+                    Architecture = $Architecture.Name
+                    Type         = Get-FileType -File $Url
+                    URI          = $Url
+                }
+                Write-Output -InputObject $PSObject
+            }
         }
-        Write-Output -InputObject $PSObject
     }
 }

--- a/Apps/Get-GoToOpener.ps1
+++ b/Apps/Get-GoToOpener.ps1
@@ -2,7 +2,6 @@
     <#
         .NOTES
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]
@@ -21,7 +20,7 @@
         $Version = [RegEx]::Match($Response.ResponseUri, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
     }
     catch {
-        $Version = "Unknown"
+        $Version = "Latest"
     }
 
     # Build the output object; Output object to the pipeline

--- a/Manifests/GoToMeeting.json
+++ b/Manifests/GoToMeeting.json
@@ -3,17 +3,14 @@
     "Source": "https://support.goto.com/meeting/help/install-via-msi-windows",
     "Get": {
         "Update": {
-            "Uri": ""
+            "Uri": "https://goto-desktop.goto.com/machine/latest.yml",
+            "MatchVersion": "^version:\\s(\\d+(\\.\\d+){1,4})"
         },
         "Download": {
             "Uri": {
-                "Latest": "https://link.gotomeeting.com/latest-msi",
-                "Minimum": "https://link.gotomeeting.com/minimum-build-msi",
-                "Multi-build": "https://link.gotomeeting.com/latest-multi-build-msi",
-                "XenAppLatest": "https://link.gotomeeting.com/latest-xen-msi"
-            },
-            "MatchVersion": "(\\d+(\\.\\d+){1,3})",
-            "Split": "\\?"
+                "x64": "https://goto-desktop.goto.com/GoToSetupMachine-4.18.0-x64.msi",
+                "x86": "https://goto-desktop.goto.com/GoToSetupMachine-4.18.0-ia32.msi"
+            }
         }
     },
     "Install": {

--- a/Manifests/GoToOpener.json
+++ b/Manifests/GoToOpener.json
@@ -6,7 +6,7 @@
             "Uri": ""
         },
         "Download": {
-            "Uri": "https://launch.getgo.com/launcher2/latest/GoToOpenerMultiUser.msi",
+            "Uri": "https://meet.goto.com/openerbinaries/latest/GoToOpenerMultiUser.msi",
             "MatchVersion": "(\\d+)"
         }
     },


### PR DESCRIPTION
* Refactor Get-GoToMeeting to resolve the Update URI (latest.yml), extract the version via a new MatchVersion regex, and emit per-architecture download entries (Architecture, Type, URI) by substituting the version into the download URLs #135.
* Change Get-GoToOpener to return "Latest" on version resolution failure.
* Update manifests: add Update.Uri and MatchVersion to Manifests/GoToMeeting.json and replace the previous generic download endpoints with explicit x64/x86 MSI URLs (removed prior MatchVersion/Split fields); update Manifests/GoToOpener.json download URI to the new domain path.