### PR TITLE
Fix Docker #146

### DIFF
--- a/Apps/Get-DockerDesktop.ps1
+++ b/Apps/Get-DockerDesktop.ps1
@@ -16,23 +16,65 @@ function Get-DockerDesktop {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Get the releases data
-    $Updates = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
+    foreach ($Url in $res.Get.Update.Uri) {
+        # Get the releases data
+        $Updates = Invoke-EvergreenRestMethod -Uri $Url
 
-    # Select the latest version
-    $Latest = $Updates | `
-        Sort-Object -Property @{ Expression = { [System.Version]$_.enclosure.shortVersionString }; Descending = $true } | `
-        Select-Object -First 1
-
-    # Output the latest version
-    foreach ($Item in $Latest.enclosure.url) {
-        $PSObject = [PSCustomObject] @{
-            Version = $Latest.enclosure.shortVersionString
-            Build   = $Latest.enclosure.version
-            Size    = $Latest.enclosure.length
-            Type    = Get-FileType -File $Item
-            URI     = $Item
+        # Keep only entries that can be version-sorted
+        $ValidUpdates = $Updates | Where-Object {
+            ($null -ne $_.enclosure) -and
+            ($null -ne $_.enclosure.shortVersionString)
         }
-        Write-Output -InputObject $PSObject
+        if ($ValidUpdates.Count -eq 0) {
+            throw "$($MyInvocation.MyCommand): No valid release entries found with enclosure.shortVersionString."
+        }
+
+        # Select the latest version
+        $Latest = $ValidUpdates | `
+            Sort-Object -Property @{ Expression = { [System.Version]$_.enclosure.shortVersionString }; Descending = $true } | `
+            Select-Object -First 1
+
+        if (($null -eq $Latest) -or ($null -eq $Latest.enclosure)) {
+            throw "$($MyInvocation.MyCommand): Latest release entry is missing enclosure data."
+        }
+
+        $RequiredEnclosureProperties = @(
+            "shortVersionString",
+            "version",
+            "length",
+            "url"
+        )
+
+        foreach ($Property in $RequiredEnclosureProperties) {
+            if (-not ($Latest.enclosure.PSObject.Properties.Name -contains $Property)) {
+                throw "$($MyInvocation.MyCommand): Latest release entry is missing required enclosure property '$Property'."
+            }
+
+            if ($null -eq $Latest.enclosure.$Property) {
+                throw "$($MyInvocation.MyCommand): Latest release enclosure property '$Property' is null."
+            }
+        }
+
+        $Urls = @($Latest.enclosure.url) | Where-Object {
+            -not [System.String]::IsNullOrWhiteSpace([System.String]$_)
+        }
+        if ($Urls.Count -eq 0) {
+            throw "$($MyInvocation.MyCommand): Latest release enclosure property 'url' has no valid values."
+        }
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Found version: $($Latest.enclosure.shortVersionString)."
+
+        # Output the latest version
+        foreach ($Item in $Urls) {
+            $PSObject = [PSCustomObject] @{
+                Version      = $Latest.enclosure.shortVersionString
+                Build        = $Latest.enclosure.version
+                Size         = $Latest.enclosure.length
+                Architecture = Get-Architecture -String $Item
+                Type         = Get-FileType -File $Item
+                FileName     = [System.IO.Path]::GetFileName($Item)
+                URI          = $Item -replace " ", "%20"
+            }
+            Write-Output -InputObject $PSObject
+        }
     }
 }

--- a/Manifests/DockerDesktop.json
+++ b/Manifests/DockerDesktop.json
@@ -3,7 +3,10 @@
     "Source": "https://www.docker.com/products/docker-desktop/",
     "Get": {
         "Update": {
-            "Uri": "https://desktop.docker.com/win/main/amd64/appcast.xml"
+            "Uri": [
+                "https://desktop.docker.com/win/main/amd64/appcast.xml",
+                "https://desktop.docker.com/win/main/arm64/appcast.xml"
+            ]
         }
     },
     "Install": {


### PR DESCRIPTION
Iterate over multiple update URIs and harden release parsing for Docker Desktop. `Get-DockerDesktop.ps1` now loops over each `Update.Uri`, filters entries with valid `enclosure.shortVersionString`, validates required enclosure properties, and emits clear errors when data is missing. Outputs include `Architecture`, `FileName` and percent-encoded URI, and verbose logging for discovered versions. `Manifests/DockerDesktop.json` changed `Update.Uri` from a single string to an array to include both `amd64` and `arm64` endpoints.