### PR TITLE
Extract version from URL when throttled

### DIFF
--- a/Apps/Get-CitrixWorkspaceApp.ps1
+++ b/Apps/Get-CitrixWorkspaceApp.ps1
@@ -39,16 +39,22 @@
             # Walk through each node to output details
             foreach ($Installer in $Installers) {
 
+                $Version = $Installer.Version
                 # Write a warning if Citrix is throttling updates
                 if ($Installer.Version -eq "0.0.0.0") {
                     Write-Warning -Message "$($MyInvocation.MyCommand): Version '0.0.0.0' detected. Citrix may be throttling availability of updates for $($Installer.ShortDescription -replace ':', '')."
+                    try {
+                        $Version = [RegEx]::Match($Installer.DownloadURL, $res.Get.Update.MatchVersion).Captures.Groups[0].Value
+                    }
+                    catch {
+                        $Version = "0.0.0.0"
+                    }
                 }
 
                 $PSObject = [PSCustomObject] @{
-                    Version = $Installer.Version
+                    Version = $Version
                     Stream  = $Installer.Stream
                     Date    = ConvertTo-DateTime -DateTime $Installer.StartDate -Pattern $res.Get.Update.DatePattern
-                    #Title   = $($Installer.ShortDescription -replace ":", "")
                     Size    = $(if ($Installer.Size) { $Installer.Size } else { "Unknown" })
                     Hash    = $Installer.Hash
                     URI     = "$($res.Get.Download.Uri)$($Installer.DownloadURL)"

--- a/Manifests/CitrixWorkspaceApp.json
+++ b/Manifests/CitrixWorkspaceApp.json
@@ -8,7 +8,8 @@
             "XmlNode": "//Installer",
             "DatePattern": "yyyy-MM-dd",
             "FilterName": "Receiver",
-            "ExpandProperty": "Installer"
+            "ExpandProperty": "Installer",
+            "MatchVersion": "(?<=CitrixWorkspaceApp)\\d+\\.\\d+\\.\\d+\\.\\d+(?=\\.exe$)"
         },
         "Download": {
             "Uri": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod"


### PR DESCRIPTION
* When Citrix returns Version `0.0.0.0` (likely due to throttling), attempt to extract the real version from the installer DownloadURL and use it in the output
* Introduced a $Version variable, added a try/catch to parse the version via the manifest-provided `MatchVersion` regex and fall back to `0.0.0.0` on failure.