### PR TITLE
Pdfx change

### DIFF
--- a/Apps/Get-TrackerSoftwarePDFTools.ps1
+++ b/Apps/Get-TrackerSoftwarePDFTools.ps1
@@ -1,0 +1,47 @@
+﻿function Get-TrackerSoftwarePDFTools {
+    <#
+        .SYNOPSIS
+            Returns the current version and download URL for the Tracker Software PDF Tools.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    try {
+        [System.XML.XMLDocument] $xmlDocument = Invoke-EvergreenWebRequest -Uri $res.Get.Update.Uri -Raw
+    }
+    catch [System.Exception] {
+        throw "$($MyInvocation.MyCommand): failed to convert feed into an XML object with: $($_.Exception.Message)"
+    }
+
+    # Build an output object by selecting installer entries from the feed
+    if ($xmlDocument -is [System.XML.XMLDocument]) {
+        foreach ($bundle in $res.Get.Update.Bundles) {
+
+            # Select the latest version
+            $Item = $xmlDocument.UpdaterData.bundle | Where-Object { $_.id -eq $bundle }
+            $Update = $Item.Update | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } | `
+                Select-Object -First 1
+
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Update.version
+                Hash         = $Update.hash
+                Architecture = Get-Architecture -String $Update.Url
+                Type         = $Update.type
+                URI          = $res.Get.Download.Uri -replace "#filename", $Update.url
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+}

--- a/Apps/Get-TrackerSoftwarePDFXChangeEditor.ps1
+++ b/Apps/Get-TrackerSoftwarePDFXChangeEditor.ps1
@@ -6,7 +6,6 @@
         .NOTES
             Site: https://stealthpuppy.com
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]
@@ -29,7 +28,7 @@
         foreach ($bundle in $res.Get.Update.Bundles) {
 
             # Select the latest version
-            $Item = $xmlDocument.TrackerUpdate.bundle | Where-Object { $_.id -eq $bundle }
+            $Item = $xmlDocument.UpdaterData.bundle | Where-Object { $_.id -eq $bundle }
             $Update = $Item.Update | `
                 Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } | `
                 Select-Object -First 1

--- a/Apps/Get-TrackerSoftwarePDFXChangePro.ps1
+++ b/Apps/Get-TrackerSoftwarePDFXChangePro.ps1
@@ -1,0 +1,47 @@
+﻿function Get-TrackerSoftwarePDFXChangePro {
+    <#
+        .SYNOPSIS
+            Returns the current version and download URL for the Tracker Software PDF-XChange Pro.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    try {
+        [System.XML.XMLDocument] $xmlDocument = Invoke-EvergreenWebRequest -Uri $res.Get.Update.Uri -Raw
+    }
+    catch [System.Exception] {
+        throw "$($MyInvocation.MyCommand): failed to convert feed into an XML object with: $($_.Exception.Message)"
+    }
+
+    # Build an output object by selecting installer entries from the feed
+    if ($xmlDocument -is [System.XML.XMLDocument]) {
+        foreach ($bundle in $res.Get.Update.Bundles) {
+
+            # Select the latest version
+            $Item = $xmlDocument.UpdaterData.bundle | Where-Object { $_.id -eq $bundle }
+            $Update = $Item.Update | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } | `
+                Select-Object -First 1
+
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Update.version
+                Hash         = $Update.hash
+                Architecture = Get-Architecture -String $Update.Url
+                Type         = $Update.type
+                URI          = $res.Get.Download.Uri -replace "#filename", $Update.url
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+}

--- a/Apps/Get-TrackerSoftwarePDFXDriverLite.ps1
+++ b/Apps/Get-TrackerSoftwarePDFXDriverLite.ps1
@@ -1,0 +1,47 @@
+﻿function Get-TrackerSoftwarePDFXDriverLite {
+    <#
+        .SYNOPSIS
+            Returns the current version and download URL for the Tracker Software PDF-XChange Driver Lite.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    try {
+        [System.XML.XMLDocument] $xmlDocument = Invoke-EvergreenWebRequest -Uri $res.Get.Update.Uri -Raw
+    }
+    catch [System.Exception] {
+        throw "$($MyInvocation.MyCommand): failed to convert feed into an XML object with: $($_.Exception.Message)"
+    }
+
+    # Build an output object by selecting installer entries from the feed
+    if ($xmlDocument -is [System.XML.XMLDocument]) {
+        foreach ($bundle in $res.Get.Update.Bundles) {
+
+            # Select the latest version
+            $Item = $xmlDocument.UpdaterData.bundle | Where-Object { $_.id -eq $bundle }
+            $Update = $Item.Update | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } | `
+                Select-Object -First 1
+
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Update.version
+                Hash         = $Update.hash
+                Architecture = Get-Architecture -String $Update.Url
+                Type         = $Update.type
+                URI          = $res.Get.Download.Uri -replace "#filename", $Update.url
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+}

--- a/Apps/Get-TrackerSoftwarePDFXDriverStandard.ps1
+++ b/Apps/Get-TrackerSoftwarePDFXDriverStandard.ps1
@@ -1,0 +1,47 @@
+﻿function Get-TrackerSoftwarePDFXDriverStandard {
+    <#
+        .SYNOPSIS
+            Returns the current version and download URL for the Tracker Software PDF-XChange Driver Standard.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    try {
+        [System.XML.XMLDocument] $xmlDocument = Invoke-EvergreenWebRequest -Uri $res.Get.Update.Uri -Raw
+    }
+    catch [System.Exception] {
+        throw "$($MyInvocation.MyCommand): failed to convert feed into an XML object with: $($_.Exception.Message)"
+    }
+
+    # Build an output object by selecting installer entries from the feed
+    if ($xmlDocument -is [System.XML.XMLDocument]) {
+        foreach ($bundle in $res.Get.Update.Bundles) {
+
+            # Select the latest version
+            $Item = $xmlDocument.UpdaterData.bundle | Where-Object { $_.id -eq $bundle }
+            $Update = $Item.Update | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } | `
+                Select-Object -First 1
+
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Update.version
+                Hash         = $Update.hash
+                Architecture = Get-Architecture -String $Update.Url
+                Type         = $Update.type
+                URI          = $res.Get.Download.Uri -replace "#filename", $Update.url
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+}

--- a/Manifests/TrackerSoftwarePDFTools.json
+++ b/Manifests/TrackerSoftwarePDFTools.json
@@ -1,0 +1,30 @@
+{
+    "Name": "Tracker Software PDF Tools",
+    "Source": "https://www.pdf-xchange.com/product/pdf-tools",
+    "Get": {
+        "Update": {
+            "Uri": "https://www.pdf-xchange.com/updater/UpdaterData.xml",
+            "ContentType": "application/xml; charset=utf-8",
+            "Bundles": [
+				"Tools.x64",
+				"Tools.x32",
+				"Tools.arm64"
+			]
+        },
+		"Download": {
+			"Uri": "https://downloads.pdf-xchange.com/#filename"
+		}
+    },
+    "Install": {
+        "Setup": "Tools*.x64.msi",
+        "Preinstall": "",
+        "Physical": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        }
+    }
+}

--- a/Manifests/TrackerSoftwarePDFXChangeEditor.json
+++ b/Manifests/TrackerSoftwarePDFXChangeEditor.json
@@ -1,9 +1,9 @@
 {
     "Name": "Tracker Software PDF X-Change Editor",
-    "Source": "https://pdf-xchange.eu/pdf-xchange-editor/index.htm",
+    "Source": "https://www.pdf-xchange.com/product/pdf-xchange-editor",
     "Get": {
         "Update": {
-            "Uri": "https://downloads.pdf-xchange.com/trackerupdate/TrackerData8.xml",
+            "Uri": "https://www.pdf-xchange.com/updater/UpdaterData.xml",
             "ContentType": "application/xml; charset=utf-8",
             "Bundles": [
 				"Editor.x64",

--- a/Manifests/TrackerSoftwarePDFXChangePro.json
+++ b/Manifests/TrackerSoftwarePDFXChangePro.json
@@ -1,0 +1,30 @@
+{
+    "Name": "Tracker Software PDF X-Change Pro",
+    "Source": "https://www.pdf-xchange.com/product/pdf-xchange-pro",
+    "Get": {
+        "Update": {
+            "Uri": "https://www.pdf-xchange.com/updater/UpdaterData.xml",
+            "ContentType": "application/xml; charset=utf-8",
+            "Bundles": [
+				"Pro.x64",
+				"Pro.x32",
+				"Pro.arm64"
+			]
+        },
+		"Download": {
+			"Uri": "https://downloads.pdf-xchange.com/#filename"
+		}
+    },
+    "Install": {
+        "Setup": "Pro*.x64.msi",
+        "Preinstall": "",
+        "Physical": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        }
+    }
+}

--- a/Manifests/TrackerSoftwarePDFXDriverLite.json
+++ b/Manifests/TrackerSoftwarePDFXDriverLite.json
@@ -1,0 +1,29 @@
+{
+    "Name": "Tracker Software PDF-XChange Driver Lite",
+    "Source": "https://www.pdf-xchange.com/product/pdf-xchange-drivers-api",
+    "Get": {
+        "Update": {
+            "Uri": "https://www.pdf-xchange.com/updater/UpdaterData.xml",
+            "ContentType": "application/xml; charset=utf-8",
+            "Bundles": [
+				"DriverStd.x64",
+				"DriverStd.x32"
+			]
+        },
+		"Download": {
+			"Uri": "https://downloads.pdf-xchange.com/#filename"
+		}
+    },
+    "Install": {
+        "Setup": "DriverStd*.x64.msi",
+        "Preinstall": "",
+        "Physical": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        }
+    }
+}

--- a/Manifests/TrackerSoftwarePDFXDriverStandard.json
+++ b/Manifests/TrackerSoftwarePDFXDriverStandard.json
@@ -1,0 +1,29 @@
+{
+    "Name": "Tracker Software PDF-XChange Driver Standard",
+    "Source": "https://www.pdf-xchange.com/product/pdf-xchange-drivers-api",
+    "Get": {
+        "Update": {
+            "Uri": "https://www.pdf-xchange.com/updater/UpdaterData.xml",
+            "ContentType": "application/xml; charset=utf-8",
+            "Bundles": [
+				"DriverStd.x64",
+				"DriverStd.x32"
+			]
+        },
+		"Download": {
+			"Uri": "https://downloads.pdf-xchange.com/#filename"
+		}
+    },
+    "Install": {
+        "Setup": "DriverStd*.x64.msi",
+        "Preinstall": "",
+        "Physical": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/qb /norestart",
+            "PostInstall": []
+        }
+    }
+}


### PR DESCRIPTION
* Fix #163 with new update URL
* Introduces four new Evergreen app functions and matching manifests for Tracker Software products: PDF Tools, PDF-XChange Pro, PDF-XChange Driver Lite, and PDF-XChange Driver Standard