### PR TITLE
Update download URL for ImageMagick

### DIFF
--- a/Manifests/ImageMagickStudioImageMagick.json
+++ b/Manifests/ImageMagickStudioImageMagick.json
@@ -8,7 +8,7 @@
 			"MatchFileTypes": "\\.exe$"
 		},
 		"Download": {
-			"Uri": "hhttps://github.com/ImageMagick/ImageMagick/releases/download/#version/ImageMagick-#version-Q16-HDRI-x64-dll.exe",
+			"Uri": "https://github.com/ImageMagick/ImageMagick/releases/download/#version/ImageMagick-#version-Q16-HDRI-x64-dll.exe",
 			"ReplaceText": "#version"
 		}
 	},

--- a/Manifests/ImageMagickStudioImageMagick.json
+++ b/Manifests/ImageMagickStudioImageMagick.json
@@ -8,7 +8,7 @@
 			"MatchFileTypes": "\\.exe$"
 		},
 		"Download": {
-			"Uri": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-#version-Q16-HDRI-x64-dll.exe",
+			"Uri": "hhttps://github.com/ImageMagick/ImageMagick/releases/download/#version/ImageMagick-#version-Q16-HDRI-x64-dll.exe",
 			"ReplaceText": "#version"
 		}
 	},


### PR DESCRIPTION
Minor change to download the .exe from the GitHub releases of the ImageMagick repo rather than their download server as this no longer has the .exe builds - only .msixbundle (the URL structure has also changed, causing current download links to redirect to the index of the archive directory):

<img width="261" height="294" alt="image" src="https://github.com/user-attachments/assets/c967f9ed-0d64-44ca-9d48-dc862a5cbdeb" />
