### PR TITLE
Refactor ImageMagick manifest

### DIFF
--- a/Apps/Get-ImageMagickStudioImageMagick.ps1
+++ b/Apps/Get-ImageMagickStudioImageMagick.ps1
@@ -5,7 +5,6 @@ function Get-ImageMagickStudioImageMagick {
 
         .NOTES
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]
@@ -18,19 +17,10 @@ function Get-ImageMagickStudioImageMagick {
 
     # Pass the repo releases API URL and return a formatted object
     $params = @{
-        Uri               = $res.Get.Update.Uri
-        MatchVersion      = $res.Get.Update.MatchVersion
-        Filter            = $res.Get.Update.MatchFileTypes
-        ReturnVersionOnly = $true
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
     }
     $object = Get-GitHubRepoRelease @params
-
-    # Build the output object
-    if ($null -ne $object) {
-        $PSObject = [PSCustomObject] @{
-            Version = $object.Version
-            URI     = $res.Get.Download.Uri -replace $res.Get.Download.ReplaceText, $object.Version
-        }
-        Write-Output -InputObject $PSObject
-    }
+    Write-Output -InputObject $object
 }

--- a/Manifests/ImageMagickStudioImageMagick.json
+++ b/Manifests/ImageMagickStudioImageMagick.json
@@ -2,15 +2,9 @@
 	"Name": "ImageMagick Studio ImageMagick",
 	"Source": "https://imagemagick.org/",
 	"Get": {
-		"Update": {
-			"Uri": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
-			"MatchVersion": "(*)",
-			"MatchFileTypes": "\\.exe$"
-		},
-		"Download": {
-			"Uri": "https://github.com/ImageMagick/ImageMagick/releases/download/#version/ImageMagick-#version-Q16-HDRI-x64-dll.exe",
-			"ReplaceText": "#version"
-		}
+		"Uri": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msix$|\\.msixbundle$"
 	},
 	"Install": {
 		"Setup": "ImageMagick*.exe",


### PR DESCRIPTION
Refactor `ImageMagickStudioImageMagick` function and manifest to find available version and downloads from the [mageMagick/ImageMagick](https://github.com/ImageMagick/ImageMagick) repo. Updates approach added in #165

## BREAKING CHANGE

* Adds additional available installers and properties to application details returned by this function. Additional filtering is required on output.