### PR TITLE
Use direct MySQL CDN download URLs

### DIFF
--- a/Apps/Get-mySQLConnectorNET.ps1
+++ b/Apps/Get-mySQLConnectorNET.ps1
@@ -16,7 +16,6 @@ function Get-mySQLConnectorNET {
 
     # Get latest repo tag
     $Tags = Get-GitHubRepoTag -Uri $res.Get.Update.Uri
-
     $Version = ($Tags | Sort-Object -Property @{ Expression = { [System.Version]$_.Tag }; Descending = $true } | Select-Object -First 1).Tag
 
     # Build the output object
@@ -27,22 +26,14 @@ function Get-mySQLConnectorNET {
             # redirect to
             # https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-8.0.40-winx64.msi
             #
-            # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
+            # The version is major.minor.patch, while the tag can have also have major.minor.patch.build
             $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Resolving: $Uri"
-
-            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
-            $params = @{
-                Uri                  = $Uri
-                UserAgent            = "Curl/8"
-            }
-            $CdnUri = Resolve-SystemNetWebRequest @params
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Architecture = $Architecture.Name
-                Type         = Get-FileType -File $CdnUri.ResponseUri.AbsoluteUri
-                URI          = $CdnUri.ResponseUri.AbsoluteUri -replace "com//", "com/"
+                Type         = Get-FileType -File $Uri
+                URI          = $Uri
             }
             Write-Output -InputObject $PSObject
         }

--- a/Apps/Get-mySQLConnectorODBC.ps1
+++ b/Apps/Get-mySQLConnectorODBC.ps1
@@ -16,7 +16,6 @@ function Get-mySQLConnectorODBC {
 
     # Get latest repo tag
     $Tags = Get-GitHubRepoTag -Uri $res.Get.Update.Uri
-
     $Version = ($Tags | Sort-Object -Property @{ Expression = { [System.Version]$_.Tag }; Descending = $true } | Select-Object -First 1).Tag
 
     # Build the output object
@@ -27,22 +26,15 @@ function Get-mySQLConnectorODBC {
             # redirect to
             # https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-8.0.40-winx64.msi
             #
-            # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
-            $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Resolving: $Uri"
-
-            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
-            $params = @{
-                Uri                  = $Uri
-                UserAgent            = "Curl/8"
-            }
-            $CdnUri = Resolve-SystemNetWebRequest @params
+            # The version is major.minor.patch, while the tag can have also have major.minor.patch.build
+            $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.') `
+                -replace $res.Get.Download.ReplaceVersionShort, (($Version -split '\.')[0..1] -join '.')
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Architecture = $Architecture.Name
-                Type         = Get-FileType -File $CdnUri.ResponseUri.AbsoluteUri
-                URI          = $CdnUri.ResponseUri.AbsoluteUri -replace "com//", "com/"
+                Type         = Get-FileType -File $Uri
+                URI          = $Uri
             }
             Write-Output -InputObject $PSObject
         }

--- a/Apps/Get-mySQLWorkbench.ps1
+++ b/Apps/Get-mySQLWorkbench.ps1
@@ -2,7 +2,6 @@ function Get-mySQLWorkbench {
     <#
         .NOTES
             Author: Aaron Parker
-
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Product name is a plural")]
@@ -16,7 +15,6 @@ function Get-mySQLWorkbench {
 
     # Get latest repo tag
     $Tags = Get-GitHubRepoTag -Uri $res.Get.Update.Uri
-
     $Version = ($Tags | Sort-Object -Property @{ Expression = { [System.Version]$_.Tag }; Descending = $true } | Select-Object -First 1).Tag
 
     # Build the output object
@@ -27,22 +25,14 @@ function Get-mySQLWorkbench {
             # redirect to
             # https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-8.0.40-winx64.msi
             #
-            # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
+            # The version is major.minor.patch, while the tag can have also have major.minor.patch.build
             $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Resolving: $Uri"
-
-            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
-            $params = @{
-                Uri                  = $Uri
-                UserAgent            = "Curl/8"
-            }
-            $CdnUri = Resolve-SystemNetWebRequest @params
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Architecture = $Architecture.Name
-                Type         = Get-FileType -File $CdnUri.ResponseUri.AbsoluteUri
-                URI          = $CdnUri.ResponseUri.AbsoluteUri -replace "com//", "com/"
+                Type         = Get-FileType -File $Uri
+                URI          = $Uri
             }
             Write-Output -InputObject $PSObject
         }

--- a/Manifests/mySQLConnectorNET.json
+++ b/Manifests/mySQLConnectorNET.json
@@ -7,7 +7,7 @@
       },
       "Download": {
         "Uri": {
-          "x64": "https://dev.mysql.com/get/Downloads/Connector-Net/mysql-connector-net-#version.msi"
+          "x64": "https://cdn.mysql.com/Downloads/Connector-Net/mysql-connector-net-#version.msi"
         },
         "ReplaceVersion": "#version"
       }

--- a/Manifests/mySQLConnectorODBC.json
+++ b/Manifests/mySQLConnectorODBC.json
@@ -7,10 +7,10 @@
 		},
 		"Download": {
 			"Uri": {
-				"x64": "https://dev.mysql.com/get/Downloads/Connector-ODBC/#versionshort/mysql-connector-odbc-#version-winx64.msi"
+				"x64": "https://cdn.mysql.com/Downloads/Connector-ODBC/#shortversion/mysql-connector-odbc-#version-winx64.msi"
 			},
 			"ReplaceVersion": "#version",
-			"ReplaceVersionShort": "#versionshort"
+			"ReplaceVersionShort": "#shortversion"
 		}
 	},
 	"Install": {

--- a/Manifests/mySQLWorkbench.json
+++ b/Manifests/mySQLWorkbench.json
@@ -7,7 +7,7 @@
 		},
 		"Download": {
 			"Uri": {
-				"x64": "https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-#version-winx64.msi"
+				"x64": "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#version-winx64.msi"
 			},
 			"ReplaceVersion": "#version"
 		}


### PR DESCRIPTION
Switch the MySQL Connector/NET, Connector/ODBC, and Workbench manifests to `cdn.mysql.com` URLs and simplify the app scripts to use those direct download links instead of resolving redirects. Fix #169 