### PR TITLE
Updates

### DIFF
--- a/Manifests/AutomatticSimplenote.json
+++ b/Manifests/AutomatticSimplenote.json
@@ -4,6 +4,6 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/Automattic/simplenote-electron/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$"
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.appx$"
 	}
 }

--- a/Manifests/RocketChat.json
+++ b/Manifests/RocketChat.json
@@ -4,6 +4,6 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/RocketChat/Rocket.Chat.Electron/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$"
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.appx$|\\.msix$|\\.msixbundle$"
 	}
 }

--- a/Manifests/WinDirStat.json
+++ b/Manifests/WinDirStat.json
@@ -4,6 +4,6 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/windirstat/windirstat/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$"
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msix$|\\.msixbundle$"
 	}
 }

--- a/Manifests/WixToolset.json
+++ b/Manifests/WixToolset.json
@@ -2,7 +2,7 @@
 	"Name": "WiX Toolset",
 	"Source": "https://wixtoolset.org/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/wixtoolset/wix3/releases/latest",
+		"Uri": "https://api.github.com/repos/wixtoolset/wix/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
 		"MatchFileTypes": "\\.exe$|\\.msi$",
 		"VersionTag": "name"


### PR DESCRIPTION
* Points the GitHub API URI to the current `wixtoolset/wix` repository instead of the archived `wixtoolset/wix3` repo.
* Expand the GitHub release file type filters for Automattic Simplenote, Rocket.Chat, and WinDirStat so Evergreen can detect newer packaged installers alongside existing .exe and .msi assets.