### PR TITLE
Add MSI to Podman and PodmanDesktop matches #178

### DIFF
--- a/Manifests/Podman.json
+++ b/Manifests/Podman.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/podman-container-tools/podman/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$"
+		"MatchFileTypes": "\\.exe$|\\.msi$"
 	},
 	"Install": {
 		"Setup": "podman-*.exe",

--- a/Manifests/PodmanDesktop.json
+++ b/Manifests/PodmanDesktop.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/podman-desktop/podman-desktop/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$"
+		"MatchFileTypes": "\\.exe$|\\.msi$"
 	},
 	"Install": {
 		"Setup": "podman-desktop*.exe",


### PR DESCRIPTION
Include .msi files alongside .exe in the MatchFileTypes filter for both Podman and Podman Desktop manifests.