### PR TITLE
Add reMarkable app

### DIFF
--- a/Apps/Get-reMarkable.ps1
+++ b/Apps/Get-reMarkable.ps1
@@ -1,0 +1,29 @@
+function Get-reMarkable {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for reMarkable.
+
+        .NOTES
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    $update = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
+    if ($null -ne $update) {
+
+        $PSObject = [PSCustomObject] @{
+            Version      = $update.enclosure.shortVersionString
+            Architecture = Get-Architecture -String $update.enclosure.url
+            Type         = Get-FileType -File $update.enclosure.url
+            URI          = $update.enclosure.url
+        }
+        Write-Output -InputObject $PSObject
+    }
+}

--- a/Manifests/reMarkable.json
+++ b/Manifests/reMarkable.json
@@ -1,0 +1,20 @@
+{
+    "Name": "reMarkable",
+    "Source": "https://remarkable.com/",
+    "Get": {
+        "Update": {
+            "Uri": "https://downloads.remarkable.com/sparkle/reMarkableWindows/Prod/appcast.xml"
+        }
+    },
+    "Install": {
+        "Setup": "reMarkable-*.exe",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
+}


### PR DESCRIPTION
Add the Evergreen app definition and manifest for reMarkable. The new function reads the vendor appcast to return the current version, installer URL, architecture, and file type. #183 

Apps/Get-reMarkable.ps1
Manifests/reMarkable.json