### PR TITLE
Add Logitech Options+ and OpenSSL Library apps

### DIFF
--- a/Apps/Get-LogitechOptionsPlus.ps1
+++ b/Apps/Get-LogitechOptionsPlus.ps1
@@ -1,0 +1,27 @@
+function Get-LogitechOptionsPlus {
+    <#
+        .SYNOPSIS
+            Returns the latest Logitech Options+ version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    $Update = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
+    if ($null -ne $Update) {
+        [PSCustomObject] @{
+            Version = $Update.version
+            Date    = ConvertTo-DateTime -DateTime $Update.lastModified -Pattern $res.Get.Update.DatePattern
+            Type    = Get-FileType -File $res.Get.Download.Uri
+            URI     = $res.Get.Download.Uri
+        }
+    }
+}

--- a/Apps/Get-OpenSSLLibrary.ps1
+++ b/Apps/Get-OpenSSLLibrary.ps1
@@ -1,0 +1,29 @@
+function Get-OpenSSLLibrary {
+    <#
+        .SYNOPSIS
+            Returns the latest OpenSSL version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Product name is a plural")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+        VersionTag   = "name"
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Manifests/LogitechOptionsPlus.json
+++ b/Manifests/LogitechOptionsPlus.json
@@ -1,0 +1,24 @@
+{
+    "Name": "Logitech Options+",
+    "Source": "https://support.logi.com/hc/en-us/articles/11570501236119-Logitech-Options-offline-installer",
+    "Get": {
+        "Update": {
+            "Uri": "https://updates.optionsplus.logitechg.com/pipeline/v2/update/optionsplus5/win/public/update.json",
+            "DatePattern": "M/d/yyyy h:mm:ss tt"
+        },
+        "Download": {
+            "Uri": "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.exe"
+        }
+    },
+    "Install": {
+        "Setup": "",
+        "Physical": {
+            "Arguments": "/quiet /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/quiet /norestart",
+            "PostInstall": []
+        }
+    }
+}

--- a/Manifests/MarcinSzeniakBulkCrapUninstaller.json
+++ b/Manifests/MarcinSzeniakBulkCrapUninstaller.json
@@ -2,7 +2,7 @@
 	"Name": "Marcin Szeniak Bulk Crap Uninstaller",
 	"Source": "https://www.bcuninstaller.com/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/Klocman/Bulk-Crap-Uninstaller/releases/latest",
+		"Uri": "https://api.github.com/repos/BCUninstaller/Bulk-Crap-Uninstaller/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
 		"MatchFileTypes": "\\.exe$|\\.msi$"
 	}

--- a/Manifests/OpenSSLLibrary.json
+++ b/Manifests/OpenSSLLibrary.json
@@ -1,0 +1,23 @@
+{
+	"Name": "OpenSSL Library",
+	"Source": "https://www.openssl.org/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/openssl/installer/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$"
+	},
+	"Install": {
+		"Setup": "OpenSSL*.msi",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
This PR adds two new Evergreen app definitions:

- Logitech Options+ #10 
- OpenSSL Library #185 

## Changes
- Added the PowerShell app function for Logitech Options+ and its matching manifest
- Added the PowerShell app function for OpenSSL Library and its matching manifest
- Fixes GitHub repo path for `MarcinSzeniakBulkCrapUninstaller`