### PR TITLE
Add Dropbox

### DIFF
--- a/Apps/Get-Dropbox.ps1
+++ b/Apps/Get-Dropbox.ps1
@@ -1,0 +1,35 @@
+function Get-Dropbox {
+    <#
+        .NOTES
+            Author: Aaron Parker
+
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Product name is a plural")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Resolve the download URL for each architecture and return a formatted object
+    foreach ($Architecture in $res.Get.Download.Architectures) {
+        $ResolvedUrl = Resolve-SystemNetWebRequest -Uri ($res.Get.Download.Uri -replace "#architecture", $Architecture)
+        if ($null -ne $ResolvedUrl) {
+
+            # Extract the version from the resolved URL using the specified regex pattern
+            $Version = $ResolvedUrl.ResponseUri.AbsoluteUri -match $res.Get.Download.MatchVersion | ForEach-Object { $Matches[1] }
+
+            [PSCustomObject]@{
+                Version      = $Version
+                Date         = $ResolvedUrl.LastModified.ToShortDateString()
+                Architecture = $Architecture
+                Size         = $ResolvedUrl.ContentLength
+                Filename     = ($ResolvedUrl.ResponseUri.AbsoluteUri -split "/")[-1] -replace "%20", " "
+                URI          = $ResolvedUrl.ResponseUri.AbsoluteUri
+            }
+        }
+    }
+}

--- a/Manifests/Dropbox.json
+++ b/Manifests/Dropbox.json
@@ -1,0 +1,27 @@
+{
+    "Name": "Dropbox",
+    "Source": "https://www.dropbox.com/install",
+    "Get": {
+        "Update": {},
+        "Download": {
+            "Uri": "https://www.dropbox.com/download?arch=#architecture&plat=win&type=full",
+            "Architectures": [
+                "x64",
+                "arm64"
+            ],
+            "MatchVersion": "Dropbox%20(\\d+(?:\\.\\d+)*)%20Offline%20Installer\\.(?:arm64|x64)\\.exe"
+        }
+    },
+    "Install": {
+        "Setup": "",
+        "Preinstall": "",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
+}


### PR DESCRIPTION
Add Dropbox support with a new app function and matching manifest that resolve architecture-specific offline installer URLs and extract versions for x64 and arm64 releases. Closes #22

Apps/Get-Dropbox.ps1
Manifests/Dropbox.json