### PR TITLE
Add VERDIMAXQDA and MicrosoftCoreutils applications

### DIFF
--- a/Apps/Get-MicrosoftCoreutils.ps1
+++ b/Apps/Get-MicrosoftCoreutils.ps1
@@ -1,0 +1,28 @@
+function Get-MicrosoftCoreutils {
+    <#
+        .SYNOPSIS
+            Returns the latest Microsoft Coreutils for Windows version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="Product name is a plural")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Apps/Get-VERDIMAXQDA.ps1
+++ b/Apps/Get-VERDIMAXQDA.ps1
@@ -1,0 +1,28 @@
+function Get-VERDIMAXQDA {
+    <#
+        .SYNOPSIS
+            Returns the latest VERDI MAXQDA version number and download.
+
+        .NOTES
+            Author: Aaron Parker
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Get the latest version information from the update feed
+    $Update = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
+    if ($null -ne $Update) {
+        [PSCustomObject]@{
+            Version = $Update.enclosure.shortVersionString
+            Size    = $Update.enclosure.length
+            Type    = Get-FileType -File $Update.enclosure.url
+            URI     = $Update.enclosure.url
+        }
+    }
+}

--- a/Manifests/MicrosoftCoreutils.json
+++ b/Manifests/MicrosoftCoreutils.json
@@ -1,0 +1,23 @@
+{
+	"Name": "Microsoft Coreutils for Windows",
+	"Source": "https://learn.microsoft.com/en-us/windows/core-utils/overview",
+	"Get": {
+		"Uri": "https://api.github.com/repos/microsoft/coreutils/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$"
+	},
+	"Install": {
+		"Setup": "Brackets*.msi",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		}
+	}
+}

--- a/Manifests/VERDIMAXQDA.json
+++ b/Manifests/VERDIMAXQDA.json
@@ -1,0 +1,20 @@
+{
+    "Name": "VERDI MAXQDA",
+    "Source": "https://www.maxqda.com/products/maxqda-verdi",
+    "Get": {
+        "Update": {
+            "Uri": "https://updates.maxqda.de/MAXQDA/MaxCastWin_64.xml"
+        }
+    },
+    "Install": {
+        "Setup": "",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
+}


### PR DESCRIPTION
* Implemented `Get-MicrosoftCoreutils` PowerShell function in `Apps/Get-MicrosoftCoreutils.ps1` to fetch the latest release information from GitHub using the parameters defined in the manifest.
* Added a manifest for `Microsoft Coreutils for Windows` in `Manifests/MicrosoftCoreutils.json`, specifying the GitHub releases API, version matching, and installer details.
* Added a manifest for `VERDI MAXQDA` in `Manifests/VERDIMAXQDA.json`, including the update feed URL and basic install structure. #202 
* Implemented `Get-VERDIMAXQDA` PowerShell function in `Apps/Get-VERDIMAXQDA.ps1` to retrieve the latest version and download URL from the application's update feed.