### PR TITLE
Update Audacity.json

### DIFF
--- a/Manifests/Audacity.json
+++ b/Manifests/Audacity.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/audacity/audacity/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$"
+		"MatchFileTypes": "\\.exe$|\\.msi$"
 	},
 	"Install": {
 		"Setup": "audacity-win*.exe",


### PR DESCRIPTION
Update the Audacity manifest release asset filter to match both `.exe` and `.msi` installers, so either packaging format can be detected from the latest GitHub release.