### PR TITLE
Update NodeVersionManager.json

### DIFF
--- a/Manifests/NodeVersionManager.json
+++ b/Manifests/NodeVersionManager.json
@@ -1,8 +1,8 @@
 {
 	"Name": "Node Version Manager",
-	"Source": "https://github.com/coreybutler/nvm-windows",
+	"Source": "https://nvm-windows.com/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/coreybutler/nvm-windows/releases/latest",
+		"Uri": "https://api.github.com/repos/nvm-windows/nvm/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
 		"MatchFileTypes": "\\.exe$|\\.zip$"
 	},


### PR DESCRIPTION
Point the manifest to the current nvm-windows project URLs by updating the homepage to nvm-windows.com and switching the GitHub API endpoint to the new repository path (nvm-windows/nvm). This keeps release lookups aligned with the active upstream.